### PR TITLE
Use binary search instead of monotonically decreasing

### DIFF
--- a/imgConverter.h
+++ b/imgConverter.h
@@ -10,11 +10,12 @@
 class ImgConverter
 {
 public:
-    ImgConverter(QImage convertImage, QString outputFilePath, int reductionAmount);
+    ImgConverter(QImage convertImage, QString outputFilePath);
 
 private:
-    void ResizeImage(QImage convertImage, QString outputFilePath, int reductionAmount);
+    void ResizeImage(QImage convertImage, QString outputFilePath);
     QImage SetAlphaChannelPixel(QImage nonAlphaImage);
+    double CalcTargetSizeRate(qint64 size);
 
 };
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -50,7 +50,7 @@ void MainWindow::PreviewImage(QString filePath)
 
 void MainWindow::onConvertButton()
 {
-    ImgConverter(_previewImage, ui->outputFilePath->text(), ui->reductionAmount->value());
+    ImgConverter(_previewImage, ui->outputFilePath->text());
 
     qDebug() << ui->outputFilePath->text();
 }

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -61,7 +61,7 @@
      <rect>
       <x>20</x>
       <y>40</y>
-      <width>341</width>
+      <width>461</width>
       <height>241</height>
      </rect>
     </property>
@@ -97,51 +97,6 @@
      <string>Output Image Path</string>
     </property>
    </widget>
-   <widget class="QSpinBox" name="reductionAmount">
-    <property name="geometry">
-     <rect>
-      <x>370</x>
-      <y>70</y>
-      <width>48</width>
-      <height>24</height>
-     </rect>
-    </property>
-    <property name="minimum">
-     <number>1</number>
-    </property>
-    <property name="maximum">
-     <number>10</number>
-    </property>
-    <property name="value">
-     <number>5</number>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>370</x>
-      <y>50</y>
-      <width>121</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Reduction amount</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>422</x>
-      <y>74</y>
-      <width>60</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>[pixel]</string>
-    </property>
-   </widget>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
@@ -149,7 +104,7 @@
      <x>0</x>
      <y>0</y>
      <width>500</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
# 概要
画像のスケールを単調減少させて目標画像サイズ以下にするのを辞めて二分探索で目標サイズを求めるように変更した

# 変更内容
目標画像サイズを3MBとし、二分探索した結果目標サイズの99～100%以内になれば探索終了とする。
この変更によりreductionAmountのUIの削除、および関連する処理を削除した。